### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/_posts/2022-11-06-Build-a-dns-server-on-NixOS.md
+++ b/_posts/2022-11-06-Build-a-dns-server-on-NixOS.md
@@ -20,7 +20,7 @@ Using a older 1080p monitor solved that for me.
 
 #### Getting started
 
-Since I used a Raspberry Pi 3 I could use the latest AArch64 image from Hydra (source: <https://nixos.wiki/wiki/NixOS_on_ARM#Installation>).
+Since I used a Raspberry Pi 3 I could use the latest AArch64 image from Hydra (source: <https://wiki.nixos.org/wiki/NixOS_on_ARM#Installation>).
 In my case that was the release-22.05 <https://hydra.nixos.org/job/nixos/release-22.05/nixos.sd_image.aarch64-linux>.
 
 Unpacking and flashing this image to the SD Card works the same as with all other Raspberry Pi images.

--- a/_posts/2023-10-01-zfs-nixos.md
+++ b/_posts/2023-10-01-zfs-nixos.md
@@ -60,7 +60,7 @@ And here is the rest of my NixOS config for ZFS:
 ```
 # Setup ZFS
 # Offical resources:
-# - https://nixos.wiki/wiki/ZFS
+# - https://wiki.nixos.org/wiki/ZFS
 # - https://openzfs.github.io/openzfs-docs/Getting%20Started/NixOS/index.html#installation
 
 # Enable support for ZSF and always use a compatible kernel
@@ -163,7 +163,7 @@ And [here](https://github.com/openzfs/zfs/discussions/15212) is my lengthy back 
 ## Other resources which where helpful
 
 - <https://openzfs.github.io/openzfs-docs/Getting%20Started/NixOS/index.html#installation>
-- <https://nixos.wiki/wiki/ZFS>
+- <https://wiki.nixos.org/wiki/ZFS>
 - <https://unix.stackexchange.com/questions/86764/understanding-dev-disk-by-folders>
 - <https://discourse.nixos.org/t/cannot-import-zfs-pool-at-boot/4805/3>
 - <https://www.reddit.com/r/zfs/comments/m0t0vd/cannot_import_more_than_one_matching_pool/>


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️